### PR TITLE
Renamed from Buttonwood to Buttonswap, updating references to the name throughout the contracts

### DIFF
--- a/src/ButtonswapERC20.sol
+++ b/src/ButtonswapERC20.sol
@@ -1,14 +1,14 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity =0.8.10;
 
-import "./interfaces/IButtonwoodERC20.sol";
+import "./interfaces/IButtonswapERC20.sol";
 import "./libraries/SafeMath.sol";
 
-contract ButtonwoodERC20 is IButtonwoodERC20 {
+contract ButtonswapERC20 is IButtonswapERC20 {
     using SafeMath for uint256;
 
-    string public constant name = "Buttonwood";
-    string public constant symbol = "BTNWD";
+    string public constant name = "Buttonswap";
+    string public constant symbol = "BTNSWP";
     uint8 public constant decimals = 18;
     uint256 public totalSupply;
     mapping(address => uint256) public balanceOf;
@@ -79,7 +79,7 @@ contract ButtonwoodERC20 is IButtonwoodERC20 {
     function permit(address owner, address spender, uint256 value, uint256 deadline, uint8 v, bytes32 r, bytes32 s)
         external
     {
-        require(deadline >= block.timestamp, "Buttonwood: EXPIRED");
+        require(deadline >= block.timestamp, "Buttonswap: EXPIRED");
         bytes32 digest = keccak256(
             abi.encodePacked(
                 "\x19\x01",
@@ -88,7 +88,7 @@ contract ButtonwoodERC20 is IButtonwoodERC20 {
             )
         );
         address recoveredAddress = ecrecover(digest, v, r, s);
-        require(recoveredAddress != address(0) && recoveredAddress == owner, "Buttonwood: INVALID_SIGNATURE");
+        require(recoveredAddress != address(0) && recoveredAddress == owner, "Buttonswap: INVALID_SIGNATURE");
         _approve(owner, spender, value);
     }
 }

--- a/src/ButtonswapFactory.sol
+++ b/src/ButtonswapFactory.sol
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity =0.8.10;
 
-import "./interfaces/IButtonwoodFactory.sol";
-import "./ButtonwoodPair.sol";
+import "./interfaces/IButtonswapFactory.sol";
+import "./ButtonswapPair.sol";
 
-contract ButtonwoodFactory is IButtonwoodFactory {
+contract ButtonswapFactory is IButtonswapFactory {
     address public feeTo;
     address public feeToSetter;
 
@@ -20,16 +20,16 @@ contract ButtonwoodFactory is IButtonwoodFactory {
     }
 
     function createPair(address tokenA, address tokenB) external returns (address pair) {
-        require(tokenA != tokenB, "Buttonwood: IDENTICAL_ADDRESSES");
+        require(tokenA != tokenB, "Buttonswap: IDENTICAL_ADDRESSES");
         (address token0, address token1) = tokenA < tokenB ? (tokenA, tokenB) : (tokenB, tokenA);
-        require(token0 != address(0), "Buttonwood: ZERO_ADDRESS");
-        require(getPair[token0][token1] == address(0), "Buttonwood: PAIR_EXISTS"); // single check is sufficient
-        bytes memory bytecode = type(ButtonwoodPair).creationCode;
+        require(token0 != address(0), "Buttonswap: ZERO_ADDRESS");
+        require(getPair[token0][token1] == address(0), "Buttonswap: PAIR_EXISTS"); // single check is sufficient
+        bytes memory bytecode = type(ButtonswapPair).creationCode;
         bytes32 salt = keccak256(abi.encodePacked(token0, token1));
         assembly {
             pair := create2(0, add(bytecode, 32), mload(bytecode), salt)
         }
-        IButtonwoodPair(pair).initialize(token0, token1);
+        IButtonswapPair(pair).initialize(token0, token1);
         getPair[token0][token1] = pair;
         getPair[token1][token0] = pair; // populate mapping in the reverse direction
         allPairs.push(pair);
@@ -37,12 +37,12 @@ contract ButtonwoodFactory is IButtonwoodFactory {
     }
 
     function setFeeTo(address _feeTo) external {
-        require(msg.sender == feeToSetter, "Buttonwood: FORBIDDEN");
+        require(msg.sender == feeToSetter, "Buttonswap: FORBIDDEN");
         feeTo = _feeTo;
     }
 
     function setFeeToSetter(address _feeToSetter) external {
-        require(msg.sender == feeToSetter, "Buttonwood: FORBIDDEN");
+        require(msg.sender == feeToSetter, "Buttonswap: FORBIDDEN");
         feeToSetter = _feeToSetter;
     }
 }

--- a/src/interfaces/IButtonswapCallee.sol
+++ b/src/interfaces/IButtonswapCallee.sol
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity =0.8.10;
+
+interface IButtonswapCallee {
+    function buttonswapCall(address sender, uint256 amount0, uint256 amount1, bytes calldata data) external;
+}

--- a/src/interfaces/IButtonswapERC20.sol
+++ b/src/interfaces/IButtonswapERC20.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity =0.8.10;
 
-interface IButtonwoodERC20 {
+interface IButtonswapERC20 {
     event Approval(address indexed owner, address indexed spender, uint256 value);
     event Transfer(address indexed from, address indexed to, uint256 value);
 

--- a/src/interfaces/IButtonswapFactory.sol
+++ b/src/interfaces/IButtonswapFactory.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity =0.8.10;
 
-interface IButtonwoodFactory {
+interface IButtonswapFactory {
     event PairCreated(address indexed token0, address indexed token1, address pair, uint256);
 
     function feeTo() external view returns (address);

--- a/src/interfaces/IButtonswapPair.sol
+++ b/src/interfaces/IButtonswapPair.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity =0.8.10;
 
-import "./IButtonwoodERC20.sol";
+import "./IButtonswapERC20.sol";
 
-interface IButtonwoodPair is IButtonwoodERC20 {
+interface IButtonswapPair is IButtonswapERC20 {
     event Mint(address indexed sender, uint256 amount0, uint256 amount1);
     event Burn(address indexed sender, uint256 amount0, uint256 amount1, address indexed to);
     event Swap(

--- a/src/interfaces/IButtonwoodCallee.sol
+++ b/src/interfaces/IButtonwoodCallee.sol
@@ -1,6 +1,0 @@
-// SPDX-License-Identifier: UNLICENSED
-pragma solidity =0.8.10;
-
-interface IButtonwoodCallee {
-    function buttonwoodCall(address sender, uint256 amount0, uint256 amount1, bytes calldata data) external;
-}


### PR DESCRIPTION
Renamed from Buttonwood to Buttonswap, updating references to the name throughout the contracts