### PR TITLE
Configure line endings to be LF across platforms

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+* text=auto
+*.sol text eol=lf


### PR DESCRIPTION
Should fix my windows environment showing eol diffs when running `forge fmt`