### PR TITLE
Splitting interfaces to facilitate tests

### DIFF
--- a/src/ButtonswapERC20.sol
+++ b/src/ButtonswapERC20.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity =0.8.10;
 
-import "./interfaces/IButtonswapERC20.sol";
+import "./interfaces/IButtonswapERC20/IButtonswapERC20.sol";
 import "./libraries/SafeMath.sol";
 
 contract ButtonswapERC20 is IButtonswapERC20 {

--- a/src/ButtonswapFactory.sol
+++ b/src/ButtonswapFactory.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity =0.8.10;
 
-import "./interfaces/IButtonswapFactory.sol";
+import "./interfaces/IButtonswapFactory/IButtonswapFactory.sol";
 import "./ButtonswapPair.sol";
 
 contract ButtonswapFactory is IButtonswapFactory {

--- a/src/ButtonswapPair.sol
+++ b/src/ButtonswapPair.sol
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity =0.8.10;
 
-import "./interfaces/IButtonswapPair.sol";
+import "./interfaces/IButtonswapPair/IButtonswapPair.sol";
 import "./ButtonswapERC20.sol";
 import "./libraries/Math.sol";
 import "./libraries/UQ112x112.sol";
-import "./interfaces/IERC20.sol";
-import "./interfaces/IButtonswapFactory.sol";
+import "./interfaces/IERC20/IERC20.sol";
+import "./interfaces/IButtonswapFactory/IButtonswapFactory.sol";
 import "./interfaces/IButtonswapCallee.sol";
 
 contract ButtonswapPair is IButtonswapPair, ButtonswapERC20 {

--- a/src/interfaces/IButtonswapERC20/IButtonswapERC20.sol
+++ b/src/interfaces/IButtonswapERC20/IButtonswapERC20.sol
@@ -1,16 +1,10 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity =0.8.10;
 
-interface IButtonswapERC20 {
-    /// @notice Permit deadline was exceeded
-    error PermitExpired();
+import "./IButtonswapERC20Errors.sol";
+import "./IButtonswapERC20Events.sol";
 
-    /// @notice Permit signature invalid
-    error PermitInvalidSignature();
-
-    event Approval(address indexed owner, address indexed spender, uint256 value);
-    event Transfer(address indexed from, address indexed to, uint256 value);
-
+interface IButtonswapERC20 is IButtonswapERC20Errors, IButtonswapERC20Events {
     function name() external pure returns (string memory);
 
     function symbol() external pure returns (string memory);

--- a/src/interfaces/IButtonswapERC20/IButtonswapERC20Errors.sol
+++ b/src/interfaces/IButtonswapERC20/IButtonswapERC20Errors.sol
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity =0.8.10;
+
+interface IButtonswapERC20Errors {
+    /// @notice Permit deadline was exceeded
+    error PermitExpired();
+
+    /// @notice Permit signature invalid
+    error PermitInvalidSignature();
+}

--- a/src/interfaces/IButtonswapERC20/IButtonswapERC20Events.sol
+++ b/src/interfaces/IButtonswapERC20/IButtonswapERC20Events.sol
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity =0.8.10;
+
+interface IButtonswapERC20Events {
+    event Approval(address indexed owner, address indexed spender, uint256 value);
+
+    event Transfer(address indexed from, address indexed to, uint256 value);
+}

--- a/src/interfaces/IButtonswapFactory/IButtonswapFactory.sol
+++ b/src/interfaces/IButtonswapFactory/IButtonswapFactory.sol
@@ -1,21 +1,10 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity =0.8.10;
 
-interface IButtonswapFactory {
-    /// @notice The given token addresses are the same
-    error TokenIdenticalAddress();
+import "./IButtonswapFactoryErrors.sol";
+import "./IButtonswapFactoryEvents.sol";
 
-    /// @notice The given token address is the zero address
-    error TokenZeroAddress();
-
-    /// @notice The give tokens already have a ButtonswapPair instance
-    error PairExists();
-
-    /// @notice User does not have permission for the attempted operation
-    error Forbidden();
-
-    event PairCreated(address indexed token0, address indexed token1, address pair, uint256);
-
+interface IButtonswapFactory is IButtonswapFactoryErrors, IButtonswapFactoryEvents {
     function feeTo() external view returns (address);
 
     function feeToSetter() external view returns (address);

--- a/src/interfaces/IButtonswapFactory/IButtonswapFactoryErrors.sol
+++ b/src/interfaces/IButtonswapFactory/IButtonswapFactoryErrors.sol
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity =0.8.10;
+
+interface IButtonswapFactoryErrors {
+    /// @notice The given token addresses are the same
+    error TokenIdenticalAddress();
+
+    /// @notice The given token address is the zero address
+    error TokenZeroAddress();
+
+    /// @notice The give tokens already have a ButtonswapPair instance
+    error PairExists();
+
+    /// @notice User does not have permission for the attempted operation
+    error Forbidden();
+}

--- a/src/interfaces/IButtonswapFactory/IButtonswapFactoryEvents.sol
+++ b/src/interfaces/IButtonswapFactory/IButtonswapFactoryEvents.sol
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity =0.8.10;
+
+interface IButtonswapFactoryEvents {
+    event PairCreated(address indexed token0, address indexed token1, address pair, uint256);
+}

--- a/src/interfaces/IButtonswapPair/IButtonswapPair.sol
+++ b/src/interfaces/IButtonswapPair/IButtonswapPair.sol
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity =0.8.10;
+
+import "./IButtonswapPairErrors.sol";
+import "./IButtonswapPairEvents.sol";
+import "../IButtonswapERC20/IButtonswapERC20.sol";
+
+interface IButtonswapPair is IButtonswapPairErrors, IButtonswapPairEvents, IButtonswapERC20 {
+    function MINIMUM_LIQUIDITY() external pure returns (uint256);
+
+    function factory() external view returns (address);
+
+    function token0() external view returns (address);
+
+    function token1() external view returns (address);
+
+    function getPools() external view returns (uint112 poolA, uint112 poolB, uint32 blockTimestampLast);
+
+    function getReservoirs() external view returns (uint112 reservoirA, uint112 reservoirB);
+
+    function price0CumulativeLast() external view returns (uint256);
+
+    function price1CumulativeLast() external view returns (uint256);
+
+    function kLast() external view returns (uint256);
+
+    function mint(address to) external returns (uint256 liquidity);
+
+    function mintWithReservoir(address to) external returns (uint256 liquidity);
+
+    function burn(address to) external returns (uint256 amountA, uint256 amountB);
+
+    function burnFromReservoir(address to) external returns (uint256 amountA, uint256 amountB);
+
+    function swap(uint256 amountAOut, uint256 amountBOut, address to, bytes calldata data) external;
+
+    function sync() external;
+
+    function initialize(address, address) external;
+}

--- a/src/interfaces/IButtonswapPair/IButtonswapPairErrors.sol
+++ b/src/interfaces/IButtonswapPair/IButtonswapPairErrors.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity =0.8.10;
 
-import "./IButtonswapERC20.sol";
+import "../IButtonswapERC20/IButtonswapERC20Errors.sol";
 
-interface IButtonswapPair is IButtonswapERC20 {
+interface IButtonswapPairErrors is IButtonswapERC20Errors {
     /// @notice Re-entrancy guard prevented method call
     error Locked();
 
@@ -60,49 +60,4 @@ interface IButtonswapPair is IButtonswapERC20 {
 
     /// @notice The product of pool balances must not change during a swap (save for accounting for fees)
     error KInvariant();
-
-    event Mint(address indexed sender, uint256 amount0, uint256 amount1);
-    event Burn(address indexed sender, uint256 amount0, uint256 amount1, address indexed to);
-    event Swap(
-        address indexed sender,
-        uint256 amount0In,
-        uint256 amount1In,
-        uint256 amount0Out,
-        uint256 amount1Out,
-        address indexed to
-    );
-    event Sync(uint112 pool0, uint112 pool1);
-    event SyncReservoir(uint112 reservoir0, uint112 reservoir1);
-
-    function MINIMUM_LIQUIDITY() external pure returns (uint256);
-
-    function factory() external view returns (address);
-
-    function token0() external view returns (address);
-
-    function token1() external view returns (address);
-
-    function getPools() external view returns (uint112 poolA, uint112 poolB, uint32 blockTimestampLast);
-
-    function getReservoirs() external view returns (uint112 reservoirA, uint112 reservoirB);
-
-    function price0CumulativeLast() external view returns (uint256);
-
-    function price1CumulativeLast() external view returns (uint256);
-
-    function kLast() external view returns (uint256);
-
-    function mint(address to) external returns (uint256 liquidity);
-
-    function mintWithReservoir(address to) external returns (uint256 liquidity);
-
-    function burn(address to) external returns (uint256 amountA, uint256 amountB);
-
-    function burnFromReservoir(address to) external returns (uint256 amountA, uint256 amountB);
-
-    function swap(uint256 amountAOut, uint256 amountBOut, address to, bytes calldata data) external;
-
-    function sync() external;
-
-    function initialize(address, address) external;
 }

--- a/src/interfaces/IButtonswapPair/IButtonswapPairEvents.sol
+++ b/src/interfaces/IButtonswapPair/IButtonswapPairEvents.sol
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity =0.8.10;
+
+import "../IButtonswapERC20/IButtonswapERC20Events.sol";
+
+interface IButtonswapPairEvents is IButtonswapERC20Events {
+    event Mint(address indexed sender, uint256 amount0, uint256 amount1);
+
+    event Burn(address indexed sender, uint256 amount0, uint256 amount1, address indexed to);
+
+    event Swap(
+        address indexed sender,
+        uint256 amount0In,
+        uint256 amount1In,
+        uint256 amount0Out,
+        uint256 amount1Out,
+        address indexed to
+    );
+
+    event Sync(uint112 pool0, uint112 pool1);
+
+    event SyncReservoir(uint112 reservoir0, uint112 reservoir1);
+}

--- a/src/interfaces/IERC20/IERC20.sol
+++ b/src/interfaces/IERC20/IERC20.sol
@@ -1,10 +1,9 @@
 // SPDX-License-Identifier: UNLICENSED
 pragma solidity =0.8.10;
 
-interface IERC20 {
-    event Approval(address indexed owner, address indexed spender, uint256 value);
-    event Transfer(address indexed from, address indexed to, uint256 value);
+import "./IERC20Events.sol";
 
+interface IERC20 is IERC20Events {
     function name() external view returns (string memory);
 
     function symbol() external view returns (string memory);

--- a/src/interfaces/IERC20/IERC20Events.sol
+++ b/src/interfaces/IERC20/IERC20Events.sol
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity =0.8.10;
+
+interface IERC20Events {
+    event Approval(address indexed owner, address indexed spender, uint256 value);
+
+    event Transfer(address indexed from, address indexed to, uint256 value);
+}


### PR DESCRIPTION
This is to facilitate writing tests in foundry. By splitting out the errors and events in the interfaces, the tests can inherit those interfaces and compare the events and errors one for one without having to implement all the methods defined in the interface too.