### PR TITLE
Renamed test functions

### DIFF
--- a/test/ButtonswapERC20.t.sol
+++ b/test/ButtonswapERC20.t.sol
@@ -20,28 +20,28 @@ contract ButtonswapERC20Test is Test, IButtonswapERC20Events, IButtonswapERC20Er
         mockButtonswapERC20 = new MockButtonswapERC20();
     }
 
-    function testName() public {
+    function test_name() public {
         assertEq(buttonswapERC20.name(), "Buttonswap");
     }
 
-    function testSymbol() public {
+    function test_symbol() public {
         assertEq(buttonswapERC20.symbol(), "BTNSWP");
     }
 
-    function testDecimals() public {
+    function test_decimals() public {
         assertEq(buttonswapERC20.decimals(), 18);
     }
 
-    function testTotalSupply() public {
+    function test_totalSupply() public {
         assertEq(buttonswapERC20.totalSupply(), 0);
     }
 
-    function testBalanceOf() public {
+    function test_balanceOf() public {
         address owner;
         assertEq(buttonswapERC20.balanceOf(owner), 0);
     }
 
-    function testDOMAIN_SEPARATOR() public {
+    function test_DOMAIN_SEPARATOR() public {
         uint256 chainId;
         assembly {
             chainId := chainid()
@@ -61,7 +61,7 @@ contract ButtonswapERC20Test is Test, IButtonswapERC20Events, IButtonswapERC20Er
         );
     }
 
-    function testMint(uint256 amount1, uint256 amount2) public {
+    function test_mint(uint256 amount1, uint256 amount2) public {
         vm.assume(amount1 <= (type(uint256).max / 2));
         vm.assume(amount2 < (type(uint256).max / 2));
 
@@ -74,7 +74,7 @@ contract ButtonswapERC20Test is Test, IButtonswapERC20Events, IButtonswapERC20Er
         assertEq(mockButtonswapERC20.balanceOf(userB), amount2);
     }
 
-    function testBurn(uint256 amount1, uint256 amount2) public {
+    function test_burn(uint256 amount1, uint256 amount2) public {
         vm.assume(amount1 <= (type(uint256).max / 2));
         vm.assume(amount2 < (type(uint256).max / 2));
 
@@ -95,7 +95,7 @@ contract ButtonswapERC20Test is Test, IButtonswapERC20Events, IButtonswapERC20Er
         assertEq(mockButtonswapERC20.balanceOf(userB), 0);
     }
 
-    function testApprove(uint256 amount) public {
+    function test_approve(uint256 amount) public {
         address owner = userA;
         address spender = userB;
 
@@ -108,7 +108,7 @@ contract ButtonswapERC20Test is Test, IButtonswapERC20Events, IButtonswapERC20Er
         assertEq(mockButtonswapERC20.allowance(owner, spender), amount);
     }
 
-    function testTransfer(uint256 initialBalance, uint256 amount) public {
+    function test_transfer(uint256 initialBalance, uint256 amount) public {
         vm.assume(amount <= initialBalance);
         address sender = userA;
         address recipient = userB;
@@ -127,7 +127,7 @@ contract ButtonswapERC20Test is Test, IButtonswapERC20Events, IButtonswapERC20Er
         assertEq(mockButtonswapERC20.balanceOf(recipient), amount);
     }
 
-    function testCannotTransferMoreThanBalance(uint256 initialBalance, uint256 amount) public {
+    function test_transfer_CannotTransferMoreThanBalance(uint256 initialBalance, uint256 amount) public {
         vm.assume(amount > initialBalance);
         address sender = userA;
         address recipient = userB;
@@ -145,7 +145,7 @@ contract ButtonswapERC20Test is Test, IButtonswapERC20Events, IButtonswapERC20Er
         assertEq(mockButtonswapERC20.balanceOf(recipient), 0);
     }
 
-    function testTransferFrom(uint256 initialBalance, uint256 amount) public {
+    function test_transferFrom(uint256 initialBalance, uint256 amount) public {
         vm.assume(amount <= initialBalance);
         // max allowance is a special case which we test elsewhere
         vm.assume(amount != type(uint256).max);
@@ -175,7 +175,7 @@ contract ButtonswapERC20Test is Test, IButtonswapERC20Events, IButtonswapERC20Er
         assertEq(mockButtonswapERC20.allowance(sender, spender), 0);
     }
 
-    function testMaxAllowanceTransferFrom(uint256 initialBalance, uint256 amount1, uint256 amount2) public {
+    function test_transferFrom_MaxAllowance(uint256 initialBalance, uint256 amount1, uint256 amount2) public {
         vm.assume(amount1 <= (type(uint256).max / 2));
         vm.assume(amount2 < (type(uint256).max / 2));
         vm.assume((amount1 + amount2) <= initialBalance);
@@ -220,7 +220,7 @@ contract ButtonswapERC20Test is Test, IButtonswapERC20Events, IButtonswapERC20Er
         assertEq(mockButtonswapERC20.allowance(sender, spender), type(uint256).max);
     }
 
-    function testCannotTransferFromMoreThanBalance(uint256 initialBalance, uint256 amount) public {
+    function test_transferFrom_CannotTransferMoreThanBalance(uint256 initialBalance, uint256 amount) public {
         vm.assume(amount > initialBalance);
         address sender = userA;
         address spender = userB;
@@ -247,7 +247,7 @@ contract ButtonswapERC20Test is Test, IButtonswapERC20Events, IButtonswapERC20Er
         assertEq(mockButtonswapERC20.allowance(sender, spender), amount);
     }
 
-    function testPermit(uint256 privateKey, uint256 amount) public {
+    function test_permit(uint256 privateKey, uint256 amount) public {
         vm.assume(Utils.isValidPrivateKey(privateKey));
 
         address owner = vm.addr(privateKey);
@@ -282,7 +282,7 @@ contract ButtonswapERC20Test is Test, IButtonswapERC20Events, IButtonswapERC20Er
         assertEq(mockButtonswapERC20.allowance(owner, spender), amount);
     }
 
-    function testCannotCallPermitWhenDeadlineInvalid(uint256 privateKey, uint256 amount) public {
+    function test_permit_CannotCallWhenDeadlineInvalid(uint256 privateKey, uint256 amount) public {
         // This test matches permit call deadline param to what was used to create the signature, but
         //   warps time beyond the value such that it has expired.
         vm.assume(Utils.isValidPrivateKey(privateKey));
@@ -320,7 +320,7 @@ contract ButtonswapERC20Test is Test, IButtonswapERC20Events, IButtonswapERC20Er
         assertEq(mockButtonswapERC20.allowance(owner, spender), 0);
     }
 
-    function testCannotCallPermitWhenDeadlineMismatch(uint256 privateKey, uint256 amount) public {
+    function test_permit_CannotCallWhenDeadlineMismatch(uint256 privateKey, uint256 amount) public {
         // This test simulates attempting to call permit with a deadline that is later than the current time, but
         //   which differs from the value used in signature (which has expired)
         vm.assume(Utils.isValidPrivateKey(privateKey));
@@ -359,7 +359,7 @@ contract ButtonswapERC20Test is Test, IButtonswapERC20Events, IButtonswapERC20Er
         assertEq(mockButtonswapERC20.allowance(owner, spender), 0);
     }
 
-    function testCannotCallPermitWhenSpenderMismatch(uint256 privateKey, uint256 amount) public {
+    function test_permit_CannotCallWhenSpenderMismatch(uint256 privateKey, uint256 amount) public {
         // This test simulates attempting to call permit with a deadline that is later than the current time, but
         //   which differs from the value used in signature (which has expired)
         vm.assume(Utils.isValidPrivateKey(privateKey));

--- a/test/ButtonswapFactory.t.sol
+++ b/test/ButtonswapFactory.t.sol
@@ -28,7 +28,7 @@ contract ButtonswapFactoryTest is Test, IButtonswapFactoryEvents, IButtonswapFac
         return tokens;
     }
 
-    function testCreatePair(
+    function test_createPair(
         address initialFeeToSetter,
         address token0A,
         address token0B,
@@ -214,7 +214,7 @@ contract ButtonswapFactoryTest is Test, IButtonswapFactoryEvents, IButtonswapFac
         assertEq(buttonswapFactory2.getPair(tokens2.B, tokens2.A), pair22);
     }
 
-    function testCannotCreatePairWithIdenticalTokens(address initialFeeToSetter, address token) public {
+    function test_createPair_CannotCreatePairWithIdenticalTokens(address initialFeeToSetter, address token) public {
         vm.assume(initialFeeToSetter != address(this));
         ButtonswapFactory buttonswapFactory = new ButtonswapFactory(initialFeeToSetter);
 
@@ -233,7 +233,7 @@ contract ButtonswapFactoryTest is Test, IButtonswapFactoryEvents, IButtonswapFac
         assertEq(buttonswapFactory.getPair(token, token), address(0));
     }
 
-    function testCannotCreatePairWithZeroAddressTokens(address initialFeeToSetter, address token) public {
+    function test_createPair_CannotCreatePairWithZeroAddressTokens(address initialFeeToSetter, address token) public {
         vm.assume(initialFeeToSetter != address(this));
         // Ensure fuzzed address is non-zero
         vm.assume(token != address(0));
@@ -264,7 +264,7 @@ contract ButtonswapFactoryTest is Test, IButtonswapFactoryEvents, IButtonswapFac
         assertEq(buttonswapFactory.getPair(token, address(0)), address(0));
     }
 
-    function testCannotCreatePairThatWasAlreadyCreated(address initialFeeToSetter, address tokenA, address tokenB)
+    function test_createPair_CannotCreatePairThatWasAlreadyCreated(address initialFeeToSetter, address tokenA, address tokenB)
         public
     {
         vm.assume(initialFeeToSetter != address(this));
@@ -313,7 +313,7 @@ contract ButtonswapFactoryTest is Test, IButtonswapFactoryEvents, IButtonswapFac
         buttonswapFactory.allPairs(1);
     }
 
-    function testSetFeeTo(address initialFeeToSetter, address feeTo) public {
+    function test_setFeeTo(address initialFeeToSetter, address feeTo) public {
         vm.assume(initialFeeToSetter != address(this));
         ButtonswapFactory buttonswapFactory = new ButtonswapFactory(initialFeeToSetter);
         assertEq(buttonswapFactory.feeTo(), address(0));
@@ -323,7 +323,7 @@ contract ButtonswapFactoryTest is Test, IButtonswapFactoryEvents, IButtonswapFac
         assertEq(buttonswapFactory.feeTo(), feeTo);
     }
 
-    function testCannotSetFeeToWhenNotFeeSetter(address initialFeeToSetter, address feeTo) public {
+    function test_setFeeTo_CannotCallWhenNotFeeSetter(address initialFeeToSetter, address feeTo) public {
         vm.assume(initialFeeToSetter != address(this));
         ButtonswapFactory buttonswapFactory = new ButtonswapFactory(initialFeeToSetter);
         assertEq(buttonswapFactory.feeTo(), address(0));
@@ -333,7 +333,7 @@ contract ButtonswapFactoryTest is Test, IButtonswapFactoryEvents, IButtonswapFac
         assertEq(buttonswapFactory.feeTo(), address(0));
     }
 
-    function testSetFeeToSetter(address initialFeeToSetter, address newFeeToSetter) public {
+    function test_setFeeToSetter(address initialFeeToSetter, address newFeeToSetter) public {
         vm.assume(initialFeeToSetter != address(this));
         ButtonswapFactory buttonswapFactory = new ButtonswapFactory(initialFeeToSetter);
         assertEq(buttonswapFactory.feeToSetter(), initialFeeToSetter);
@@ -343,7 +343,7 @@ contract ButtonswapFactoryTest is Test, IButtonswapFactoryEvents, IButtonswapFac
         assertEq(buttonswapFactory.feeToSetter(), newFeeToSetter);
     }
 
-    function testCannotSetFeeToSetterWhenNotFeeSetter(address initialFeeToSetter, address newFeeToSetter) public {
+    function test_setFeeToSetter_CannotCallWhenNotFeeSetter(address initialFeeToSetter, address newFeeToSetter) public {
         vm.assume(initialFeeToSetter != address(this));
         ButtonswapFactory buttonswapFactory = new ButtonswapFactory(initialFeeToSetter);
         assertEq(buttonswapFactory.feeToSetter(), initialFeeToSetter);

--- a/test/ButtonswapPair.t.sol
+++ b/test/ButtonswapPair.t.sol
@@ -63,7 +63,7 @@ contract ButtonswapPairTest is Test, IButtonswapPairEvents, IButtonswapPairError
         rebasingTokenB = ICommonMockRebasingERC20(address(new MockUFragments()));
     }
 
-    function testInitialize(address factory, address token0, address token1) public {
+    function test_initialize(address factory, address token0, address token1) public {
         vm.assume(factory != address(this));
 
         vm.prank(factory);
@@ -88,7 +88,7 @@ contract ButtonswapPairTest is Test, IButtonswapPairEvents, IButtonswapPairError
         assertEq(reservoir1, 0);
     }
 
-    function testCannotInitializeWhenNotCreator(address factory, address token0, address token1) public {
+    function test_initialize_CannotCallWhenNotCreator(address factory, address token0, address token1) public {
         vm.assume(factory != address(this));
 
         vm.prank(factory);
@@ -102,7 +102,7 @@ contract ButtonswapPairTest is Test, IButtonswapPairEvents, IButtonswapPairError
         pair.initialize(token0, token1);
     }
 
-    function testCreateViaFactory(address token0, address token1) public {
+    function test_initialize_CreateViaFactory(address token0, address token1) public {
         TestVariables memory vars;
         vars.feeToSetter = userA;
         vars.feeTo = userB;

--- a/test/libraries/Math.t.sol
+++ b/test/libraries/Math.t.sol
@@ -5,18 +5,18 @@ import "forge-std/Test.sol";
 import {Math} from "src/libraries/Math.sol";
 
 contract MathTest is Test {
-    function testMin(uint256 value1, uint256 value2) public {
+    function test_min(uint256 value1, uint256 value2) public {
         uint256 min = Math.min(value1, value2);
         assertLe(min, value1);
         assertLe(min, value2);
     }
 
-    function testSqrt(uint256 root) public {
+    function test_sqrt(uint256 root) public {
         vm.assume(root < 2 ** 128);
         assertEq(Math.sqrt(root * root), root);
     }
 
-    function testSpecificSqrt() public {
+    function test_sqrt_SpecificValues() public {
         assertEq(Math.sqrt(0), 0);
         assertEq(Math.sqrt(1), 1);
         assertEq(Math.sqrt(2), 1);


### PR DESCRIPTION
Renamed test functions to adhere to hierarchical naming convention which makes them easier to read in console output