### PR TITLE
ci(pat): Fixing ci private-repo-access

### DIFF
--- a/.github/workflows/test-on-pr.yml
+++ b/.github/workflows/test-on-pr.yml
@@ -16,6 +16,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
+          token: ${{ secrets.BUTTONWOOD_CORE_CI_TOKEN }}
           submodules: recursive
 
       - name: Install Foundry

--- a/.github/workflows/test-on-push.yml
+++ b/.github/workflows/test-on-push.yml
@@ -16,6 +16,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
+          token: ${{ secrets.BUTTONWOOD_CORE_CI_TOKEN }}
           submodules: recursive
 
       - name: Install Foundry


### PR DESCRIPTION
## Changes:
- Attempt 2 at giving CI private-repo-access to mock-contracts

## Tests:
- [x] This is the test

## Reviewers:
@Fiddlekins 