### PR TITLE
fix(buttonswap-pair): fixing unequal-mint check

### DIFF
--- a/src/ButtonswapPair.sol
+++ b/src/ButtonswapPair.sol
@@ -368,9 +368,13 @@ contract ButtonswapPair is IButtonswapPair, ButtonswapERC20 {
             liquidity = Math.sqrt(amount0.mul(amount1)).sub(MINIMUM_LIQUIDITY);
             _mint(address(0), MINIMUM_LIQUIDITY); // permanently lock the first MINIMUM_LIQUIDITY tokens
         } else {
+            // Check that value0AddedInTermsOf1 == amount1 or value1AddedInTermsOf0 == amount0
             uint256 value0AddedInTermsOf1 = (_pool1.mul(amount0)) / _pool0;
             if (value0AddedInTermsOf1 != amount1) {
-                revert UnequalMint();
+                uint256 value1AddedInTermsOf0 = (_pool0.mul(amount1)) / _pool1;
+                if (value1AddedInTermsOf0 != amount0) {
+                    revert UnequalMint();
+                }
             }
             uint256 reservoir0InTermsOf1 = (_pool1.mul(_reservoir0)) / _pool0;
 


### PR DESCRIPTION
## Changes:
- It always checks that amount1 is equal invalue to amount0, but if amount1 is calculated based off of amount0, you end up with rounding errors that will trigger the error
- This fix does the check both ways (either amount1InTermsOf0 = amount0 OR amount0InTermsOf1 = amount1).

## Tests:
- Passes unit tests

## Reviewers:
@Fiddlekins 