### PR TITLE
refactor(ibuttonswap-pair): adding swappable-reservoir-limit function to interface

### DIFF
--- a/src/ButtonswapPair.sol
+++ b/src/ButtonswapPair.sol
@@ -337,8 +337,7 @@ contract ButtonswapPair is IButtonswapPair, ButtonswapERC20 {
     }
 
     /**
-     * @notice Returns the current limit on the number of reservoir tokens that can be exchanged during a single-sided mint/burn operation.
-     * @return swappableReservoirLimit The amount of reservoir token that can be exchanged
+     * @inheritdoc IButtonswapPair
      */
     function getSwappableReservoirLimit() external view returns (uint256 swappableReservoirLimit) {
         uint256 total0 = IERC20(token0).balanceOf(address(this));

--- a/src/interfaces/IButtonswapPair/IButtonswapPair.sol
+++ b/src/interfaces/IButtonswapPair/IButtonswapPair.sol
@@ -89,6 +89,12 @@ interface IButtonswapPair is IButtonswapPairErrors, IButtonswapPairEvents, IButt
         returns (uint128 swappableReservoirLimitReachesMaxDeadline);
 
     /**
+     * @notice Returns the current limit on the number of reservoir tokens that can be exchanged during a single-sided mint/burn operation.
+     * @return swappableReservoirLimit The amount of reservoir token that can be exchanged
+     */
+    function getSwappableReservoirLimit() external view returns (uint256 swappableReservoirLimit);
+
+    /**
      * @notice Get the current liquidity values.
      * @return _pool0 The active `token0` liquidity
      * @return _pool1 The active `token1` liquidity

--- a/test/ButtonswapPair-Template.sol
+++ b/test/ButtonswapPair-Template.sol
@@ -1390,10 +1390,7 @@ abstract contract ButtonswapPairTest is Test, IButtonswapPairEvents, IButtonswap
                 amount1X,
                 0,
                 PairMathExtended.getMaximumSingleSidedMintLiquidityMintAmountA(
-                    vars.pair.getSwappableReservoirLimit(),
-                    vars.total0,
-                    vars.total1,
-                    vars.pair.movingAveragePrice0()
+                    vars.pair.getSwappableReservoirLimit(), vars.total0, vars.total1, vars.pair.movingAveragePrice0()
                 )
             );
 
@@ -1422,10 +1419,7 @@ abstract contract ButtonswapPairTest is Test, IButtonswapPairEvents, IButtonswap
                 amount1X,
                 0,
                 PairMathExtended.getMaximumSingleSidedMintLiquidityMintAmountB(
-                    vars.pair.getSwappableReservoirLimit(),
-                    vars.total0,
-                    vars.total1,
-                    vars.pair.movingAveragePrice0()
+                    vars.pair.getSwappableReservoirLimit(), vars.total0, vars.total1, vars.pair.movingAveragePrice0()
                 )
             );
 
@@ -2196,8 +2190,7 @@ abstract contract ButtonswapPairTest is Test, IButtonswapPairEvents, IButtonswap
 
             // Relying on vm.assume gives us too many rejections, so instead scale input down if it exceeds the limit
             if (swappedReservoirAmount1 > vars.pair.getSwappableReservoirLimit()) {
-                burnAmount = (burnAmount * vars.pair.getSwappableReservoirLimit())
-                    / swappedReservoirAmount1;
+                burnAmount = (burnAmount * vars.pair.getSwappableReservoirLimit()) / swappedReservoirAmount1;
                 (expectedAmount1, swappedReservoirAmount1) = PairMath.getSingleSidedBurnOutputAmountB(
                     vars.pair.totalSupply(), burnAmount, vars.total0, vars.total1, vars.pair.movingAveragePrice0()
                 );
@@ -2214,8 +2207,7 @@ abstract contract ButtonswapPairTest is Test, IButtonswapPairEvents, IButtonswap
 
             // Relying on vm.assume gives us too many rejections, so instead scale input down if it exceeds the limit
             if (swappedReservoirAmount0 > vars.pair.getSwappableReservoirLimit()) {
-                burnAmount = (burnAmount * vars.pair.getSwappableReservoirLimit())
-                    / swappedReservoirAmount0;
+                burnAmount = (burnAmount * vars.pair.getSwappableReservoirLimit()) / swappedReservoirAmount0;
                 (expectedAmount0, swappedReservoirAmount0) = PairMath.getSingleSidedBurnOutputAmountA(
                     vars.pair.totalSupply(), burnAmount, vars.total0, vars.total1, vars.pair.movingAveragePrice0()
                 );
@@ -2372,8 +2364,7 @@ abstract contract ButtonswapPairTest is Test, IButtonswapPairEvents, IButtonswap
 
             // Relying on vm.assume gives us too many rejections, so instead scale input down if it exceeds the limit
             if (swappedReservoirAmount1 > vars.pair.getSwappableReservoirLimit()) {
-                burnAmount = (burnAmount * vars.pair.getSwappableReservoirLimit())
-                    / swappedReservoirAmount1;
+                burnAmount = (burnAmount * vars.pair.getSwappableReservoirLimit()) / swappedReservoirAmount1;
                 (expectedAmount1, swappedReservoirAmount1) = PairMath.getSingleSidedBurnOutputAmountB(
                     vars.pair.totalSupply(), burnAmount, vars.total0, vars.total1, vars.pair.movingAveragePrice0()
                 );
@@ -2390,8 +2381,7 @@ abstract contract ButtonswapPairTest is Test, IButtonswapPairEvents, IButtonswap
 
             // Relying on vm.assume gives us too many rejections, so instead scale input down if it exceeds the limit
             if (swappedReservoirAmount0 > vars.pair.getSwappableReservoirLimit()) {
-                burnAmount = (burnAmount * vars.pair.getSwappableReservoirLimit())
-                    / swappedReservoirAmount0;
+                burnAmount = (burnAmount * vars.pair.getSwappableReservoirLimit()) / swappedReservoirAmount0;
                 (expectedAmount0, swappedReservoirAmount0) = PairMath.getSingleSidedBurnOutputAmountA(
                     vars.pair.totalSupply(), burnAmount, vars.total0, vars.total1, vars.pair.movingAveragePrice0()
                 );


### PR DESCRIPTION
## Changes
- Adding the `getSwappableReservoirLimit()` function to `IButtonswapPair`
- Running `forge fmt`

## Testing :
- [x] Passes all unit tests

## Reviewers:
@Fiddlekins 
