### PR TITLE
PROM-933-22-src-buttonswap-pair-sol

### DIFF
--- a/src/ButtonswapPair.sol
+++ b/src/ButtonswapPair.sol
@@ -329,7 +329,7 @@ contract ButtonswapPair is IButtonswapPair, ButtonswapERC20 {
         if (_swappableReservoirLimitReachesMaxDeadline > block.timestamp) {
             // If the current deadline is still active then calculate the progress towards reaching it
             uint256 progress =
-            SWAPPABLE_RESERVOIR_GROWTH_WINDOW - (_swappableReservoirLimitReachesMaxDeadline - block.timestamp);
+                SWAPPABLE_RESERVOIR_GROWTH_WINDOW - (_swappableReservoirLimitReachesMaxDeadline - block.timestamp);
             // The greater the progress, the closer to the max limit we get
             swappableReservoir = (maxSwappableReservoirLimit * progress) / SWAPPABLE_RESERVOIR_GROWTH_WINDOW;
         } else {


### PR DESCRIPTION
## Changes
- stopped caching block.timestamp as direct access is more efficient
- stopped caching token0 and token1 since now that they're immutable "direct access" is more efficient

## Testing :
- forge test
