### PR TITLE
PROM-984-m-5-fund-locking-vulnerability-via-is-paused-setter-role

### DIFF
--- a/src/ButtonswapPair.sol
+++ b/src/ButtonswapPair.sol
@@ -591,15 +591,15 @@ contract ButtonswapPair is IButtonswapPair, ButtonswapERC20 {
         sendOrRefundFee
         returns (uint256 amountOut0, uint256 amountOut1)
     {
+        if (liquidityIn == 0) {
+            revert InsufficientLiquidityBurned();
+        }
         uint256 _totalSupply = totalSupply;
         uint256 total0 = IERC20(token0).balanceOf(address(this));
         uint256 total1 = IERC20(token1).balanceOf(address(this));
 
         (amountOut0, amountOut1) = PairMath.getDualSidedBurnOutputAmounts(_totalSupply, liquidityIn, total0, total1);
 
-        if (amountOut0 == 0 || amountOut1 == 0) {
-            revert InsufficientLiquidityBurned();
-        }
         _burn(msg.sender, liquidityIn);
         SafeERC20.safeTransfer(IERC20(token0), to, amountOut0);
         SafeERC20.safeTransfer(IERC20(token1), to, amountOut1);

--- a/test/ButtonswapPair-Template.sol
+++ b/test/ButtonswapPair-Template.sol
@@ -1626,13 +1626,11 @@ abstract contract ButtonswapPairTest is Test, IButtonswapPairEvents, IButtonswap
 
     function test_burn_CannotCallWithInsufficientLiquidityBurned(
         uint256 mintAmount0,
-        uint256 mintAmount1,
-        uint256 burnAmount
+        uint256 mintAmount1
     ) public {
         // Make sure the amounts aren't liable to overflow 2**112
         vm.assume(mintAmount0 < (2 ** 112) / 2);
         vm.assume(mintAmount1 < (2 ** 112) / 2);
-        vm.assume(burnAmount < (2 ** 112) / 2);
         // Amounts must be non-zero, and must exceed minimum liquidity
         vm.assume(mintAmount0 > 1000);
         vm.assume(mintAmount1 > 1000);
@@ -1658,23 +1656,10 @@ abstract contract ButtonswapPairTest is Test, IButtonswapPairEvents, IButtonswap
         vars.pair.mint(mintAmount0, mintAmount1, vars.minter1);
         vm.stopPrank();
 
-        // burnAmount must not exceed amount of liquidity tokens minter has
-        vm.assume(burnAmount <= vars.pair.balanceOf(vars.minter1));
-        // Calculate expected values to assert against
-        (vars.pool0, vars.pool1, vars.reservoir0, vars.reservoir1,) = vars.pair.getLiquidityBalances();
-        (uint256 expectedAmount0, uint256 expectedAmount1) = PairMath.getDualSidedBurnOutputAmounts(
-            vars.pair.totalSupply(),
-            burnAmount,
-            vars.token0.balanceOf(address(vars.pair)),
-            vars.token1.balanceOf(address(vars.pair))
-        );
-        // Target edge cases where one or both expected amounts are zero
-        vm.assume(expectedAmount0 == 0 || expectedAmount1 == 0);
-
         // Attempt burn
         vm.startPrank(vars.minter1);
         vm.expectRevert(InsufficientLiquidityBurned.selector);
-        vars.pair.burn(burnAmount, vars.receiver);
+        vars.pair.burn(0, vars.receiver);
         vm.stopPrank();
     }
 


### PR DESCRIPTION
## Changes
- adjusted dual burn condition to protect against attempts to burn zero LP tokens for non-zero output, whilst no longer preventing output being zero. This prevents LPers being stuck in a scenario where one token has been drained to the point that they get zero back when burning LP. Routers handle any required slippage protection

## Testing :
- unit tests
