### PR TITLE
PROM-1004-update-bswap-core-swappable-reservoir-limit-to-5

### DIFF
--- a/src/ButtonswapFactory.sol
+++ b/src/ButtonswapFactory.sol
@@ -53,7 +53,7 @@ contract ButtonswapFactory is IButtonswapFactory {
     /**
      * @inheritdoc IButtonswapFactory
      */
-    uint16 public defaultMaxSwappableReservoirLimitBps = 1000;
+    uint16 public defaultMaxSwappableReservoirLimitBps = 500;
 
     /**
      * @inheritdoc IButtonswapFactory


### PR DESCRIPTION
## Changes
- updated defaultMaxSwappableReservoirLimitBps to 5%

## Testing :
- unit tests
