### PR TITLE
PROM-1010-buttonswap-make-lp-token-name-symbol-configurable

### DIFF
--- a/src/ButtonswapERC20.sol
+++ b/src/ButtonswapERC20.sol
@@ -7,16 +7,6 @@ contract ButtonswapERC20 is IButtonswapERC20 {
     /**
      * @inheritdoc IButtonswapERC20
      */
-    string public constant name = "Buttonswap";
-
-    /**
-     * @inheritdoc IButtonswapERC20
-     */
-    string public constant symbol = "BTNSWP";
-
-    /**
-     * @inheritdoc IButtonswapERC20
-     */
     uint8 public constant decimals = 18;
 
     /**
@@ -60,7 +50,7 @@ contract ButtonswapERC20 is IButtonswapERC20 {
         DOMAIN_SEPARATOR = keccak256(
             abi.encode(
                 keccak256("EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)"),
-                keccak256(bytes(name)),
+                keccak256(bytes("Buttonswap")),
                 keccak256(bytes("1")),
                 chainId,
                 address(this)
@@ -119,6 +109,20 @@ contract ButtonswapERC20 is IButtonswapERC20 {
         balanceOf[from] = balanceOf[from] - value;
         balanceOf[to] = balanceOf[to] + value;
         emit Transfer(from, to, value);
+    }
+
+    /**
+     * @inheritdoc IButtonswapERC20
+     */
+    function name() external view virtual override returns (string memory _name) {
+        _name = "Buttonswap";
+    }
+
+    /**
+     * @inheritdoc IButtonswapERC20
+     */
+    function symbol() external view virtual override returns (string memory _symbol) {
+        _symbol = "BTNSWP";
     }
 
     /**

--- a/src/ButtonswapFactory.sol
+++ b/src/ButtonswapFactory.sol
@@ -36,6 +36,16 @@ contract ButtonswapFactory is IButtonswapFactory {
     address public paramSetter;
 
     /**
+     * @inheritdoc IButtonswapFactory
+     */
+    string public tokenName;
+
+    /**
+     * @inheritdoc IButtonswapFactory
+     */
+    string public tokenSymbol;
+
+    /**
      * @dev The upper limit on what duration parameters can be set to.
      */
     uint32 public constant MAX_DURATION_BOUND = 12 weeks;
@@ -106,17 +116,23 @@ contract ButtonswapFactory is IButtonswapFactory {
      * @param _isCreationRestrictedSetter The account that has the ability to set `isCreationRestrictedSetter` and `isCreationRestricted`
      * @param _isPausedSetter The account that has the ability to set `isPausedSetter` and `isPaused`
      * @param _paramSetter The account that has the ability to set `paramSetter`, default parameters, and current parameters on existing pairs
+     * @param _tokenName The name of the ERC20 liquidity token
+     * @param _tokenSymbol The symbol of the ERC20 liquidity token
      */
     constructor(
         address _feeToSetter,
         address _isCreationRestrictedSetter,
         address _isPausedSetter,
-        address _paramSetter
+        address _paramSetter,
+        string memory _tokenName,
+        string memory _tokenSymbol
     ) {
         feeToSetter = _feeToSetter;
         isCreationRestrictedSetter = _isCreationRestrictedSetter;
         isPausedSetter = _isPausedSetter;
         paramSetter = _paramSetter;
+        tokenName = _tokenName;
+        tokenSymbol = _tokenSymbol;
     }
 
     /**

--- a/src/ButtonswapPair.sol
+++ b/src/ButtonswapPair.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.13;
 
 import {IButtonswapPair} from "./interfaces/IButtonswapPair/IButtonswapPair.sol";
+import {IButtonswapERC20} from "./interfaces/IButtonswapERC20/IButtonswapERC20.sol";
 import {ButtonswapERC20} from "./ButtonswapERC20.sol";
 import {Math} from "./libraries/Math.sol";
 import {PairMath} from "./libraries/PairMath.sol";
@@ -206,6 +207,20 @@ contract ButtonswapPair is IButtonswapPair, ButtonswapERC20 {
             maxSwappableReservoirLimitBps,
             swappableReservoirGrowthWindow
         ) = IButtonswapFactory(factory).lastCreatedTokensAndParameters();
+    }
+
+    /**
+     * @inheritdoc IButtonswapERC20
+     */
+    function name() external view override(ButtonswapERC20, IButtonswapERC20) returns (string memory _name) {
+        _name = IButtonswapFactory(factory).tokenName();
+    }
+
+    /**
+     * @inheritdoc IButtonswapERC20
+     */
+    function symbol() external view override(ButtonswapERC20, IButtonswapERC20) returns (string memory _symbol) {
+        _symbol = IButtonswapFactory(factory).tokenSymbol();
     }
 
     /**

--- a/src/interfaces/IButtonswapERC20/IButtonswapERC20.sol
+++ b/src/interfaces/IButtonswapERC20/IButtonswapERC20.sol
@@ -7,15 +7,15 @@ import {IButtonswapERC20Events} from "./IButtonswapERC20Events.sol";
 interface IButtonswapERC20 is IButtonswapERC20Errors, IButtonswapERC20Events {
     /**
      * @notice Returns the name of the token.
-     * @return name The token name
+     * @return _name The token name
      */
-    function name() external pure returns (string memory name);
+    function name() external view returns (string memory _name);
 
     /**
      * @notice Returns the symbol of the token, usually a shorter version of the name.
-     * @return symbol The token symbol
+     * @return _symbol The token symbol
      */
-    function symbol() external pure returns (string memory symbol);
+    function symbol() external view returns (string memory _symbol);
 
     /**
      * @notice Returns the number of decimals used to get its user representation.

--- a/src/interfaces/IButtonswapFactory/IButtonswapFactory.sol
+++ b/src/interfaces/IButtonswapFactory/IButtonswapFactory.sol
@@ -20,6 +20,18 @@ interface IButtonswapFactory is IButtonswapFactoryErrors, IButtonswapFactoryEven
     function feeToSetter() external view returns (address _feeToSetter);
 
     /**
+     * @notice The name of the ERC20 liquidity token.
+     * @return _tokenName The `tokenName`
+     */
+    function tokenName() external view returns (string memory _tokenName);
+
+    /**
+     * @notice The symbol of the ERC20 liquidity token.
+     * @return _tokenSymbol The `tokenSymbol`
+     */
+    function tokenSymbol() external view returns (string memory _tokenSymbol);
+
+    /**
      * @notice Returns the current state of restricted creation.
      * If true, then no new pairs, only feeToSetter can create new pairs
      * @return _isCreationRestricted The `isCreationRestricted` state

--- a/test/ButtonswapFactory.t.sol
+++ b/test/ButtonswapFactory.t.sol
@@ -69,9 +69,9 @@ contract ButtonswapFactoryTest is Test, IButtonswapFactoryEvents, IButtonswapFac
 
         // Two factories so we can test that token param order doesn't matter
         ButtonswapFactory buttonswapFactory1 =
-        new ButtonswapFactory(initialFeeToSetter, initialIsCreationRestrictedSetter, initialIsPausedSetter, initialParamSetter);
+        new ButtonswapFactory(initialFeeToSetter, initialIsCreationRestrictedSetter, initialIsPausedSetter, initialParamSetter, "Test Name", "TEST");
         ButtonswapFactory buttonswapFactory2 =
-        new ButtonswapFactory(initialFeeToSetter, initialIsCreationRestrictedSetter, initialIsPausedSetter, initialParamSetter);
+        new ButtonswapFactory(initialFeeToSetter, initialIsCreationRestrictedSetter, initialIsPausedSetter, initialParamSetter, "Test Name", "TEST");
 
         assertEq(buttonswapFactory1.allPairsLength(), 0);
         vm.expectRevert();
@@ -225,7 +225,7 @@ contract ButtonswapFactoryTest is Test, IButtonswapFactoryEvents, IButtonswapFac
         address token
     ) public {
         ButtonswapFactory buttonswapFactory =
-        new ButtonswapFactory(initialFeeToSetter, initialIsCreationRestrictedSetter, initialIsPausedSetter, initialParamSetter);
+        new ButtonswapFactory(initialFeeToSetter, initialIsCreationRestrictedSetter, initialIsPausedSetter, initialParamSetter, "Test Name", "TEST");
 
         assertEq(buttonswapFactory.allPairsLength(), 0);
         vm.expectRevert();
@@ -252,7 +252,7 @@ contract ButtonswapFactoryTest is Test, IButtonswapFactoryEvents, IButtonswapFac
         // Ensure fuzzed address is non-zero
         vm.assume(token != address(0));
         ButtonswapFactory buttonswapFactory =
-        new ButtonswapFactory(initialFeeToSetter, initialIsCreationRestrictedSetter, initialIsPausedSetter, initialParamSetter);
+        new ButtonswapFactory(initialFeeToSetter, initialIsCreationRestrictedSetter, initialIsPausedSetter, initialParamSetter, "Test Name", "TEST");
 
         assertEq(buttonswapFactory.allPairsLength(), 0);
         vm.expectRevert();
@@ -295,7 +295,7 @@ contract ButtonswapFactoryTest is Test, IButtonswapFactoryEvents, IButtonswapFac
         // Calculate sorted token pairs
         Tokens memory tokens = getTokens(tokenA, tokenB);
         ButtonswapFactory buttonswapFactory =
-        new ButtonswapFactory(initialFeeToSetter, initialIsCreationRestrictedSetter, initialIsPausedSetter, initialParamSetter);
+        new ButtonswapFactory(initialFeeToSetter, initialIsCreationRestrictedSetter, initialIsPausedSetter, initialParamSetter, "Test Name", "TEST");
 
         assertEq(buttonswapFactory.allPairsLength(), 0);
         vm.expectRevert();
@@ -351,7 +351,7 @@ contract ButtonswapFactoryTest is Test, IButtonswapFactoryEvents, IButtonswapFac
         // Calculate sorted token pairs
         Tokens memory tokens = getTokens(tokenA, tokenB);
         ButtonswapFactory buttonswapFactory =
-        new ButtonswapFactory(initialFeeToSetter, initialIsCreationRestrictedSetter, initialIsPausedSetter, initialParamSetter);
+        new ButtonswapFactory(initialFeeToSetter, initialIsCreationRestrictedSetter, initialIsPausedSetter, initialParamSetter, "Test Name", "TEST");
 
         // IsCreationRestrictedSetter locking pair creation
         vm.prank(initialIsCreationRestrictedSetter);
@@ -380,7 +380,7 @@ contract ButtonswapFactoryTest is Test, IButtonswapFactoryEvents, IButtonswapFac
         // Calculate sorted token pairs
         Tokens memory tokens = getTokens(tokenA, tokenB);
         ButtonswapFactory buttonswapFactory =
-        new ButtonswapFactory(initialFeeToSetter, initialIsCreationRestrictedSetter, initialIsPausedSetter, initialParamSetter);
+        new ButtonswapFactory(initialFeeToSetter, initialIsCreationRestrictedSetter, initialIsPausedSetter, initialParamSetter, "Test Name", "TEST");
 
         // IsCreationRestrictedSetter locking pair creation
         vm.prank(initialIsCreationRestrictedSetter);
@@ -399,7 +399,7 @@ contract ButtonswapFactoryTest is Test, IButtonswapFactoryEvents, IButtonswapFac
         address initialIsPausedSetter = address(0);
         address initialParamSetter = address(0);
         ButtonswapFactory buttonswapFactory =
-        new ButtonswapFactory(initialFeeToSetter, initialIsCreationRestrictedSetter, initialIsPausedSetter, initialParamSetter);
+        new ButtonswapFactory(initialFeeToSetter, initialIsCreationRestrictedSetter, initialIsPausedSetter, initialParamSetter, "Test Name", "TEST");
         assertEq(buttonswapFactory.feeTo(), address(0));
 
         vm.prank(initialFeeToSetter);
@@ -415,7 +415,7 @@ contract ButtonswapFactoryTest is Test, IButtonswapFactoryEvents, IButtonswapFac
         address initialIsPausedSetter = address(0);
         address initialParamSetter = address(0);
         ButtonswapFactory buttonswapFactory =
-        new ButtonswapFactory(initialFeeToSetter, initialIsCreationRestrictedSetter, initialIsPausedSetter, initialParamSetter);
+        new ButtonswapFactory(initialFeeToSetter, initialIsCreationRestrictedSetter, initialIsPausedSetter, initialParamSetter, "Test Name", "TEST");
         assertEq(buttonswapFactory.feeTo(), address(0));
 
         vm.startPrank(caller);
@@ -430,7 +430,7 @@ contract ButtonswapFactoryTest is Test, IButtonswapFactoryEvents, IButtonswapFac
         address initialIsPausedSetter = address(0);
         address initialParamSetter = address(0);
         ButtonswapFactory buttonswapFactory =
-        new ButtonswapFactory(initialFeeToSetter, initialIsCreationRestrictedSetter, initialIsPausedSetter, initialParamSetter);
+        new ButtonswapFactory(initialFeeToSetter, initialIsCreationRestrictedSetter, initialIsPausedSetter, initialParamSetter, "Test Name", "TEST");
         assertEq(buttonswapFactory.feeToSetter(), initialFeeToSetter);
 
         vm.prank(initialFeeToSetter);
@@ -448,7 +448,7 @@ contract ButtonswapFactoryTest is Test, IButtonswapFactoryEvents, IButtonswapFac
         address initialIsPausedSetter = address(0);
         address initialParamSetter = address(0);
         ButtonswapFactory buttonswapFactory =
-        new ButtonswapFactory(initialFeeToSetter, initialIsCreationRestrictedSetter, initialIsPausedSetter, initialParamSetter);
+        new ButtonswapFactory(initialFeeToSetter, initialIsCreationRestrictedSetter, initialIsPausedSetter, initialParamSetter, "Test Name", "TEST");
         assertEq(buttonswapFactory.feeToSetter(), initialFeeToSetter);
 
         vm.startPrank(caller);
@@ -465,7 +465,7 @@ contract ButtonswapFactoryTest is Test, IButtonswapFactoryEvents, IButtonswapFac
         address initialIsPausedSetter = address(0);
         address initialParamSetter = address(0);
         ButtonswapFactory buttonswapFactory =
-        new ButtonswapFactory(initialFeeToSetter, initialIsCreationRestrictedSetter, initialIsPausedSetter, initialParamSetter);
+        new ButtonswapFactory(initialFeeToSetter, initialIsCreationRestrictedSetter, initialIsPausedSetter, initialParamSetter, "Test Name", "TEST");
         assertEq(buttonswapFactory.isCreationRestricted(), false);
 
         vm.prank(initialIsCreationRestrictedSetter);
@@ -483,7 +483,7 @@ contract ButtonswapFactoryTest is Test, IButtonswapFactoryEvents, IButtonswapFac
         address initialIsPausedSetter = address(0);
         address initialParamSetter = address(0);
         ButtonswapFactory buttonswapFactory =
-        new ButtonswapFactory(initialFeeToSetter, initialIsCreationRestrictedSetter, initialIsPausedSetter, initialParamSetter);
+        new ButtonswapFactory(initialFeeToSetter, initialIsCreationRestrictedSetter, initialIsPausedSetter, initialParamSetter, "Test Name", "TEST");
         assertEq(buttonswapFactory.isCreationRestricted(), false);
 
         vm.startPrank(caller);
@@ -501,7 +501,7 @@ contract ButtonswapFactoryTest is Test, IButtonswapFactoryEvents, IButtonswapFac
         address initialIsPausedSetter = address(0);
         address initialParamSetter = address(0);
         ButtonswapFactory buttonswapFactory =
-        new ButtonswapFactory(initialFeeToSetter, initialIsCreationRestrictedSetter, initialIsPausedSetter, initialParamSetter);
+        new ButtonswapFactory(initialFeeToSetter, initialIsCreationRestrictedSetter, initialIsPausedSetter, initialParamSetter, "Test Name", "TEST");
         assertEq(buttonswapFactory.isCreationRestrictedSetter(), initialIsCreationRestrictedSetter);
 
         vm.prank(initialIsCreationRestrictedSetter);
@@ -519,7 +519,7 @@ contract ButtonswapFactoryTest is Test, IButtonswapFactoryEvents, IButtonswapFac
         address initialIsPausedSetter = address(0);
         address initialParamSetter = address(0);
         ButtonswapFactory buttonswapFactory =
-        new ButtonswapFactory(initialFeeToSetter, initialIsCreationRestrictedSetter, initialIsPausedSetter, initialParamSetter);
+        new ButtonswapFactory(initialFeeToSetter, initialIsCreationRestrictedSetter, initialIsPausedSetter, initialParamSetter, "Test Name", "TEST");
         assertEq(buttonswapFactory.isCreationRestrictedSetter(), initialIsCreationRestrictedSetter);
 
         vm.startPrank(caller);
@@ -536,7 +536,7 @@ contract ButtonswapFactoryTest is Test, IButtonswapFactoryEvents, IButtonswapFac
 
         vm.assume(tokenA != tokenB && tokenA != address(0) && tokenB != address(0));
         ButtonswapFactory buttonswapFactory =
-        new ButtonswapFactory(initialFeeToSetter, initialIsCreationRestrictedSetter, initialIsPausedSetter, initialParamSetter);
+        new ButtonswapFactory(initialFeeToSetter, initialIsCreationRestrictedSetter, initialIsPausedSetter, initialParamSetter, "Test Name", "TEST");
         address pairAddress = buttonswapFactory.createPair(tokenA, tokenB);
         address[] memory pairAddresses = new address[](1);
         pairAddresses[0] = pairAddress;
@@ -561,7 +561,7 @@ contract ButtonswapFactoryTest is Test, IButtonswapFactoryEvents, IButtonswapFac
 
         vm.assume(tokenA != tokenB && tokenA != address(0) && tokenB != address(0));
         ButtonswapFactory buttonswapFactory =
-        new ButtonswapFactory(initialFeeToSetter, initialIsCreationRestrictedSetter, initialIsPausedSetter, initialParamSetter);
+        new ButtonswapFactory(initialFeeToSetter, initialIsCreationRestrictedSetter, initialIsPausedSetter, initialParamSetter, "Test Name", "TEST");
         address pairAddress = buttonswapFactory.createPair(tokenA, tokenB);
         address[] memory pairAddresses = new address[](1);
         pairAddresses[0] = pairAddress;
@@ -576,7 +576,7 @@ contract ButtonswapFactoryTest is Test, IButtonswapFactoryEvents, IButtonswapFac
         address initialIsCreationRestrictedSetter = address(0);
         address initialParamSetter = address(0);
         ButtonswapFactory buttonswapFactory =
-        new ButtonswapFactory(initialFeeToSetter, initialIsCreationRestrictedSetter, initialIsPausedSetter, initialParamSetter);
+        new ButtonswapFactory(initialFeeToSetter, initialIsCreationRestrictedSetter, initialIsPausedSetter, initialParamSetter, "Test Name", "TEST");
         assertEq(buttonswapFactory.isPausedSetter(), initialIsPausedSetter);
 
         vm.prank(initialIsPausedSetter);
@@ -594,7 +594,7 @@ contract ButtonswapFactoryTest is Test, IButtonswapFactoryEvents, IButtonswapFac
         address initialIsCreationRestrictedSetter = address(0);
         address initialParamSetter = address(0);
         ButtonswapFactory buttonswapFactory =
-        new ButtonswapFactory(initialFeeToSetter, initialIsCreationRestrictedSetter, initialIsPausedSetter, initialParamSetter);
+        new ButtonswapFactory(initialFeeToSetter, initialIsCreationRestrictedSetter, initialIsPausedSetter, initialParamSetter, "Test Name", "TEST");
         assertEq(buttonswapFactory.isPausedSetter(), initialIsPausedSetter);
 
         vm.startPrank(caller);
@@ -609,7 +609,7 @@ contract ButtonswapFactoryTest is Test, IButtonswapFactoryEvents, IButtonswapFac
         address initialIsCreationRestrictedSetter = address(0);
         address initialIsPausedSetter = address(0);
         ButtonswapFactory buttonswapFactory =
-        new ButtonswapFactory(initialFeeToSetter, initialIsCreationRestrictedSetter, initialIsPausedSetter, initialParamSetter);
+        new ButtonswapFactory(initialFeeToSetter, initialIsCreationRestrictedSetter, initialIsPausedSetter, initialParamSetter, "Test Name", "TEST");
         assertEq(buttonswapFactory.paramSetter(), initialParamSetter);
 
         vm.prank(initialParamSetter);
@@ -627,7 +627,7 @@ contract ButtonswapFactoryTest is Test, IButtonswapFactoryEvents, IButtonswapFac
         address initialIsCreationRestrictedSetter = address(0);
         address initialIsPausedSetter = address(0);
         ButtonswapFactory buttonswapFactory =
-        new ButtonswapFactory(initialFeeToSetter, initialIsCreationRestrictedSetter, initialIsPausedSetter, initialParamSetter);
+        new ButtonswapFactory(initialFeeToSetter, initialIsCreationRestrictedSetter, initialIsPausedSetter, initialParamSetter, "Test Name", "TEST");
         assertEq(buttonswapFactory.paramSetter(), initialParamSetter);
 
         vm.startPrank(caller);
@@ -650,7 +650,7 @@ contract ButtonswapFactoryTest is Test, IButtonswapFactoryEvents, IButtonswapFac
         address initialIsCreationRestrictedSetter = address(0);
         address initialIsPausedSetter = address(0);
         ButtonswapFactory buttonswapFactory =
-        new ButtonswapFactory(initialFeeToSetter, initialIsCreationRestrictedSetter, initialIsPausedSetter, initialParamSetter);
+        new ButtonswapFactory(initialFeeToSetter, initialIsCreationRestrictedSetter, initialIsPausedSetter, initialParamSetter, "Test Name", "TEST");
 
         newDefaultMovingAverageWindow = uint32(
             bound(
@@ -713,7 +713,7 @@ contract ButtonswapFactoryTest is Test, IButtonswapFactoryEvents, IButtonswapFac
     ) public {
         vm.assume(caller != initialParamSetter);
         ButtonswapFactory buttonswapFactory =
-            new ButtonswapFactory(address(0), address(0), address(0), initialParamSetter);
+            new ButtonswapFactory(address(0), address(0), address(0), initialParamSetter, "Test Name", "TEST");
 
         uint256 initialDefaultMovingAverageWindow = buttonswapFactory.defaultMovingAverageWindow();
         uint256 initialDefaultMaxVolatilityBps = buttonswapFactory.defaultMaxVolatilityBps();
@@ -758,7 +758,7 @@ contract ButtonswapFactoryTest is Test, IButtonswapFactoryEvents, IButtonswapFac
 
         vm.assume(tokenA != tokenB && tokenA != address(0) && tokenB != address(0));
         ButtonswapFactory buttonswapFactory =
-        new ButtonswapFactory(initialFeeToSetter, initialIsCreationRestrictedSetter, initialIsPausedSetter, initialParamSetter);
+        new ButtonswapFactory(initialFeeToSetter, initialIsCreationRestrictedSetter, initialIsPausedSetter, initialParamSetter, "Test Name", "TEST");
         address pairAddress = buttonswapFactory.createPair(tokenA, tokenB);
         address[] memory pairAddresses = new address[](1);
         pairAddresses[0] = pairAddress;
@@ -793,7 +793,7 @@ contract ButtonswapFactoryTest is Test, IButtonswapFactoryEvents, IButtonswapFac
 
         vm.assume(tokenA != tokenB && tokenA != address(0) && tokenB != address(0));
         ButtonswapFactory buttonswapFactory =
-        new ButtonswapFactory(initialFeeToSetter, initialIsCreationRestrictedSetter, initialIsPausedSetter, initialParamSetter);
+        new ButtonswapFactory(initialFeeToSetter, initialIsCreationRestrictedSetter, initialIsPausedSetter, initialParamSetter, "Test Name", "TEST");
         address pairAddress = buttonswapFactory.createPair(tokenA, tokenB);
         address[] memory pairAddresses = new address[](1);
         pairAddresses[0] = pairAddress;
@@ -822,7 +822,7 @@ contract ButtonswapFactoryTest is Test, IButtonswapFactoryEvents, IButtonswapFac
 
         vm.assume(tokenA != tokenB && tokenA != address(0) && tokenB != address(0));
         ButtonswapFactory buttonswapFactory =
-        new ButtonswapFactory(initialFeeToSetter, initialIsCreationRestrictedSetter, initialIsPausedSetter, initialParamSetter);
+        new ButtonswapFactory(initialFeeToSetter, initialIsCreationRestrictedSetter, initialIsPausedSetter, initialParamSetter, "Test Name", "TEST");
         address pairAddress = buttonswapFactory.createPair(tokenA, tokenB);
         address[] memory pairAddresses = new address[](1);
         pairAddresses[0] = pairAddress;
@@ -844,7 +844,7 @@ contract ButtonswapFactoryTest is Test, IButtonswapFactoryEvents, IButtonswapFac
 
         vm.assume(tokenA != tokenB && tokenA != address(0) && tokenB != address(0));
         ButtonswapFactory buttonswapFactory =
-        new ButtonswapFactory(initialFeeToSetter, initialIsCreationRestrictedSetter, initialIsPausedSetter, initialParamSetter);
+        new ButtonswapFactory(initialFeeToSetter, initialIsCreationRestrictedSetter, initialIsPausedSetter, initialParamSetter, "Test Name", "TEST");
         address pairAddress = buttonswapFactory.createPair(tokenA, tokenB);
         address[] memory pairAddresses = new address[](1);
         pairAddresses[0] = pairAddress;
@@ -871,7 +871,7 @@ contract ButtonswapFactoryTest is Test, IButtonswapFactoryEvents, IButtonswapFac
 
         vm.assume(tokenA != tokenB && tokenA != address(0) && tokenB != address(0));
         ButtonswapFactory buttonswapFactory =
-        new ButtonswapFactory(initialFeeToSetter, initialIsCreationRestrictedSetter, initialIsPausedSetter, initialParamSetter);
+        new ButtonswapFactory(initialFeeToSetter, initialIsCreationRestrictedSetter, initialIsPausedSetter, initialParamSetter, "Test Name", "TEST");
         address pairAddress = buttonswapFactory.createPair(tokenA, tokenB);
         address[] memory pairAddresses = new address[](1);
         pairAddresses[0] = pairAddress;
@@ -897,7 +897,7 @@ contract ButtonswapFactoryTest is Test, IButtonswapFactoryEvents, IButtonswapFac
 
         vm.assume(tokenA != tokenB && tokenA != address(0) && tokenB != address(0));
         ButtonswapFactory buttonswapFactory =
-        new ButtonswapFactory(initialFeeToSetter, initialIsCreationRestrictedSetter, initialIsPausedSetter, initialParamSetter);
+        new ButtonswapFactory(initialFeeToSetter, initialIsCreationRestrictedSetter, initialIsPausedSetter, initialParamSetter, "Test Name", "TEST");
         address pairAddress = buttonswapFactory.createPair(tokenA, tokenB);
         address[] memory pairAddresses = new address[](1);
         pairAddresses[0] = pairAddress;
@@ -919,7 +919,7 @@ contract ButtonswapFactoryTest is Test, IButtonswapFactoryEvents, IButtonswapFac
 
         vm.assume(tokenA != tokenB && tokenA != address(0) && tokenB != address(0));
         ButtonswapFactory buttonswapFactory =
-        new ButtonswapFactory(initialFeeToSetter, initialIsCreationRestrictedSetter, initialIsPausedSetter, initialParamSetter);
+        new ButtonswapFactory(initialFeeToSetter, initialIsCreationRestrictedSetter, initialIsPausedSetter, initialParamSetter, "Test Name", "TEST");
         address pairAddress = buttonswapFactory.createPair(tokenA, tokenB);
         address[] memory pairAddresses = new address[](1);
         pairAddresses[0] = pairAddress;
@@ -948,7 +948,7 @@ contract ButtonswapFactoryTest is Test, IButtonswapFactoryEvents, IButtonswapFac
 
         vm.assume(tokenA != tokenB && tokenA != address(0) && tokenB != address(0));
         ButtonswapFactory buttonswapFactory =
-        new ButtonswapFactory(initialFeeToSetter, initialIsCreationRestrictedSetter, initialIsPausedSetter, initialParamSetter);
+        new ButtonswapFactory(initialFeeToSetter, initialIsCreationRestrictedSetter, initialIsPausedSetter, initialParamSetter, "Test Name", "TEST");
         address pairAddress = buttonswapFactory.createPair(tokenA, tokenB);
         address[] memory pairAddresses = new address[](1);
         pairAddresses[0] = pairAddress;
@@ -974,7 +974,7 @@ contract ButtonswapFactoryTest is Test, IButtonswapFactoryEvents, IButtonswapFac
 
         vm.assume(tokenA != tokenB && tokenA != address(0) && tokenB != address(0));
         ButtonswapFactory buttonswapFactory =
-        new ButtonswapFactory(initialFeeToSetter, initialIsCreationRestrictedSetter, initialIsPausedSetter, initialParamSetter);
+        new ButtonswapFactory(initialFeeToSetter, initialIsCreationRestrictedSetter, initialIsPausedSetter, initialParamSetter, "Test Name", "TEST");
         address pairAddress = buttonswapFactory.createPair(tokenA, tokenB);
         address[] memory pairAddresses = new address[](1);
         pairAddresses[0] = pairAddress;
@@ -996,7 +996,7 @@ contract ButtonswapFactoryTest is Test, IButtonswapFactoryEvents, IButtonswapFac
 
         vm.assume(tokenA != tokenB && tokenA != address(0) && tokenB != address(0));
         ButtonswapFactory buttonswapFactory =
-        new ButtonswapFactory(initialFeeToSetter, initialIsCreationRestrictedSetter, initialIsPausedSetter, initialParamSetter);
+        new ButtonswapFactory(initialFeeToSetter, initialIsCreationRestrictedSetter, initialIsPausedSetter, initialParamSetter, "Test Name", "TEST");
         address pairAddress = buttonswapFactory.createPair(tokenA, tokenB);
         address[] memory pairAddresses = new address[](1);
         pairAddresses[0] = pairAddress;
@@ -1025,7 +1025,7 @@ contract ButtonswapFactoryTest is Test, IButtonswapFactoryEvents, IButtonswapFac
 
         vm.assume(tokenA != tokenB && tokenA != address(0) && tokenB != address(0));
         ButtonswapFactory buttonswapFactory =
-        new ButtonswapFactory(initialFeeToSetter, initialIsCreationRestrictedSetter, initialIsPausedSetter, initialParamSetter);
+        new ButtonswapFactory(initialFeeToSetter, initialIsCreationRestrictedSetter, initialIsPausedSetter, initialParamSetter, "Test Name", "TEST");
         address pairAddress = buttonswapFactory.createPair(tokenA, tokenB);
         address[] memory pairAddresses = new address[](1);
         pairAddresses[0] = pairAddress;
@@ -1051,7 +1051,7 @@ contract ButtonswapFactoryTest is Test, IButtonswapFactoryEvents, IButtonswapFac
 
         vm.assume(tokenA != tokenB && tokenA != address(0) && tokenB != address(0));
         ButtonswapFactory buttonswapFactory =
-        new ButtonswapFactory(initialFeeToSetter, initialIsCreationRestrictedSetter, initialIsPausedSetter, initialParamSetter);
+        new ButtonswapFactory(initialFeeToSetter, initialIsCreationRestrictedSetter, initialIsPausedSetter, initialParamSetter, "Test Name", "TEST");
         address pairAddress = buttonswapFactory.createPair(tokenA, tokenB);
         address[] memory pairAddresses = new address[](1);
         pairAddresses[0] = pairAddress;
@@ -1073,7 +1073,7 @@ contract ButtonswapFactoryTest is Test, IButtonswapFactoryEvents, IButtonswapFac
 
         vm.assume(tokenA != tokenB && tokenA != address(0) && tokenB != address(0));
         ButtonswapFactory buttonswapFactory =
-        new ButtonswapFactory(initialFeeToSetter, initialIsCreationRestrictedSetter, initialIsPausedSetter, initialParamSetter);
+        new ButtonswapFactory(initialFeeToSetter, initialIsCreationRestrictedSetter, initialIsPausedSetter, initialParamSetter, "Test Name", "TEST");
         address pairAddress = buttonswapFactory.createPair(tokenA, tokenB);
         address[] memory pairAddresses = new address[](1);
         pairAddresses[0] = pairAddress;
@@ -1103,7 +1103,7 @@ contract ButtonswapFactoryTest is Test, IButtonswapFactoryEvents, IButtonswapFac
 
         vm.assume(tokenA != tokenB && tokenA != address(0) && tokenB != address(0));
         ButtonswapFactory buttonswapFactory =
-        new ButtonswapFactory(initialFeeToSetter, initialIsCreationRestrictedSetter, initialIsPausedSetter, initialParamSetter);
+        new ButtonswapFactory(initialFeeToSetter, initialIsCreationRestrictedSetter, initialIsPausedSetter, initialParamSetter, "Test Name", "TEST");
         address pairAddress = buttonswapFactory.createPair(tokenA, tokenB);
         address[] memory pairAddresses = new address[](1);
         pairAddresses[0] = pairAddress;
@@ -1129,7 +1129,7 @@ contract ButtonswapFactoryTest is Test, IButtonswapFactoryEvents, IButtonswapFac
 
         vm.assume(tokenA != tokenB && tokenA != address(0) && tokenB != address(0));
         ButtonswapFactory buttonswapFactory =
-        new ButtonswapFactory(initialFeeToSetter, initialIsCreationRestrictedSetter, initialIsPausedSetter, initialParamSetter);
+        new ButtonswapFactory(initialFeeToSetter, initialIsCreationRestrictedSetter, initialIsPausedSetter, initialParamSetter, "Test Name", "TEST");
         address pairAddress = buttonswapFactory.createPair(tokenA, tokenB);
         address[] memory pairAddresses = new address[](1);
         pairAddresses[0] = pairAddress;
@@ -1151,7 +1151,7 @@ contract ButtonswapFactoryTest is Test, IButtonswapFactoryEvents, IButtonswapFac
 
         vm.assume(tokenA != tokenB && tokenA != address(0) && tokenB != address(0));
         ButtonswapFactory buttonswapFactory =
-        new ButtonswapFactory(initialFeeToSetter, initialIsCreationRestrictedSetter, initialIsPausedSetter, initialParamSetter);
+        new ButtonswapFactory(initialFeeToSetter, initialIsCreationRestrictedSetter, initialIsPausedSetter, initialParamSetter, "Test Name", "TEST");
         address pairAddress = buttonswapFactory.createPair(tokenA, tokenB);
         address[] memory pairAddresses = new address[](1);
         pairAddresses[0] = pairAddress;
@@ -1186,7 +1186,7 @@ contract ButtonswapFactoryTest is Test, IButtonswapFactoryEvents, IButtonswapFac
 
         vm.assume(tokenA != tokenB && tokenA != address(0) && tokenB != address(0));
         ButtonswapFactory buttonswapFactory =
-        new ButtonswapFactory(initialFeeToSetter, initialIsCreationRestrictedSetter, initialIsPausedSetter, initialParamSetter);
+        new ButtonswapFactory(initialFeeToSetter, initialIsCreationRestrictedSetter, initialIsPausedSetter, initialParamSetter, "Test Name", "TEST");
         address pairAddress = buttonswapFactory.createPair(tokenA, tokenB);
         address[] memory pairAddresses = new address[](1);
         pairAddresses[0] = pairAddress;
@@ -1215,7 +1215,7 @@ contract ButtonswapFactoryTest is Test, IButtonswapFactoryEvents, IButtonswapFac
 
         vm.assume(tokenA != tokenB && tokenA != address(0) && tokenB != address(0));
         ButtonswapFactory buttonswapFactory =
-        new ButtonswapFactory(initialFeeToSetter, initialIsCreationRestrictedSetter, initialIsPausedSetter, initialParamSetter);
+        new ButtonswapFactory(initialFeeToSetter, initialIsCreationRestrictedSetter, initialIsPausedSetter, initialParamSetter, "Test Name", "TEST");
         address pairAddress = buttonswapFactory.createPair(tokenA, tokenB);
         address[] memory pairAddresses = new address[](1);
         pairAddresses[0] = pairAddress;
@@ -1243,7 +1243,7 @@ contract ButtonswapFactoryTest is Test, IButtonswapFactoryEvents, IButtonswapFac
         address expectedToken1 = tokenA < tokenB ? tokenB : tokenA;
 
         ButtonswapFactory buttonswapFactory =
-            new ButtonswapFactory(address(0), address(0), address(0), initialParamSetter);
+            new ButtonswapFactory(address(0), address(0), address(0), initialParamSetter, "Test Name", "TEST");
 
         newDefaultMovingAverageWindow = uint32(
             bound(

--- a/test/ButtonswapPair-Template.sol
+++ b/test/ButtonswapPair-Template.sol
@@ -97,6 +97,20 @@ abstract contract ButtonswapPairTest is Test, IButtonswapPairEvents, IButtonswap
         vm.warp(100 days);
     }
 
+    function test_name() public {
+        TestVariables memory vars;
+        vars.factory = new MockButtonswapFactory(vars.permissionSetter);
+        vars.pair = ButtonswapPair(vars.factory.mockCreatePair(address(tokenA), address(tokenB)));
+        assertEq(vars.pair.name(), "Test Name");
+    }
+
+    function test_symbol() public {
+        TestVariables memory vars;
+        vars.factory = new MockButtonswapFactory(vars.permissionSetter);
+        vars.pair = ButtonswapPair(vars.factory.mockCreatePair(address(tokenA), address(tokenB)));
+        assertEq(vars.pair.symbol(), "TEST");
+    }
+
     function test_getLiquidityBalances_ReturnsZeroBeforeFirstMint(bytes32 factorySalt) public {
         MockButtonswapFactory factory = new MockButtonswapFactory{salt: factorySalt}(userA);
         ButtonswapPair pair = ButtonswapPair(factory.mockCreatePair(address(tokenA), address(tokenB)));

--- a/test/mocks/MockButtonswapFactory.sol
+++ b/test/mocks/MockButtonswapFactory.sol
@@ -8,7 +8,7 @@ import {MockButtonswapPair} from "./MockButtonswapPair.sol";
 contract MockButtonswapFactory is ButtonswapFactory {
     // Simplified constructor for testing
     constructor(address _permissionSetter)
-        ButtonswapFactory(_permissionSetter, _permissionSetter, _permissionSetter, _permissionSetter)
+        ButtonswapFactory(_permissionSetter, _permissionSetter, _permissionSetter, _permissionSetter, "Test Name", "TEST")
     {}
 
     function mockCreatePair(address tokenA, address tokenB) external returns (address pair) {


### PR DESCRIPTION
## Changes
- The liquidity token name and symbol are now defined at the time of deploying the factory, rather than being hardcoded

## Testing :
- [x] Added new unit tests to confirm parameters
- [x] Updated existing unit tests to use constructor args

## Reviewers:
@SocksNFlops 